### PR TITLE
add package: mesa-demos

### DIFF
--- a/packages/mesa-demos/LICENSE
+++ b/packages/mesa-demos/LICENSE
@@ -1,0 +1,83 @@
+The Mesa 3D Graphics Library
+
+Disclaimer
+
+   Mesa is a 3-D graphics library with an API which is very similar to
+   that of [1]OpenGL.* To the extent that Mesa utilizes the OpenGL command
+   syntax or state machine, it is being used with authorization from
+   [2]Silicon Graphics, Inc.(SGI). However, the author does not possess an
+   OpenGL license from SGI, and makes no claim that Mesa is in any way a
+   compatible replacement for OpenGL or associated with SGI. Those who
+   want a licensed implementation of OpenGL should contact a licensed
+   vendor.
+
+   Please do not refer to the library as MesaGL (for legal reasons). It's
+   just Mesa or The Mesa 3-D graphics library.
+
+   * OpenGL is a trademark of [3]Silicon Graphics Incorporated.
+
+License / Copyright Information
+
+   The Mesa distribution consists of several components. Different
+   copyrights and licenses apply to different components. For example, the
+   GLX client code uses the SGI Free Software License B, and some of the
+   Mesa device drivers are copyrighted by their authors. See below for a
+   list of Mesa's main components and the license for each.
+
+   The core Mesa library is licensed according to the terms of the MIT
+   license. This allows integration with the XFree86, Xorg and DRI
+   projects.
+
+   The default Mesa license is as follows:
+
+Copyright (C) 1999-2007  Brian Paul   All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Attention, Contributors
+
+   When contributing to the Mesa project you must agree to the licensing
+   terms of the component to which you're contributing. The following
+   section lists the primary components of the Mesa distribution and their
+   respective licenses.
+
+Mesa Component Licenses
+
+Component         Location               License
+------------------------------------------------------------------
+Main Mesa code    src/mesa/              MIT
+
+Device drivers    src/mesa/drivers/*     MIT, generally
+
+Gallium code      src/gallium/           MIT
+
+Ext headers       include/GL/glext.h     Khronos
+                  include/GL/glxext.h
+
+GLX client code   src/glx/               SGI Free Software License B
+
+C11 thread        include/c11/threads*.h Boost (permissive) emulation
+
+   In general, consult the source files for license terms.
+
+References
+
+   1. https://www.opengl.org/
+   2. https://www.sgi.com/
+   3. https://www.sgi.com/

--- a/packages/mesa-demos/build.sh
+++ b/packages/mesa-demos/build.sh
@@ -1,0 +1,23 @@
+TERMUX_PKG_HOMEPAGE=https://www.mesa3d.org
+TERMUX_PKG_DESCRIPTION="OpenGL demonstration and test programs"
+TERMUX_PKG_LICENSE="MIT"
+TERMUX_PKG_MAINTAINER="Rafael Kitover <rkitover@gmail.com>"
+TERMUX_PKG_VERSION=8.4.0
+TERMUX_PKG_SRCURL=https://archive.mesa3d.org//demos/mesa-demos-${TERMUX_PKG_VERSION}.tar.bz2
+TERMUX_PKG_SHA256=01e99c94a0184e63e796728af89bfac559795fb2a0d6f506fa900455ca5fff7d
+
+TERMUX_PKG_DEPENDS="libx11, mesa, glu, libdrm, freetype, libxext, glew, freeglut"
+
+TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
+CFLAGS=-std=gnu11
+"
+
+termux_step_pre_configure() {
+	sed -i '/tests /d' src/Makefile.am
+	sed -i 's/ -lpthread//' src/xdemos/Makefile.am
+	autoreconf -fi
+}
+
+termux_step_install_license() {
+	install -Dm600 -t $TERMUX_PREFIX/share/doc/mesa-demos $TERMUX_PKG_BUILDER_DIR/LICENSE
+}


### PR DESCRIPTION
This package provides useful utilities to test and get information about
available OpenGL support such as glxinfo and glxgears.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>