### PR TITLE
add package: devilspie

### DIFF
--- a/packages/devilspie/build.sh
+++ b/packages/devilspie/build.sh
@@ -1,0 +1,17 @@
+TERMUX_PKG_HOMEPAGE=https://wiki.gnome.org/Projects/DevilsPie
+TERMUX_PKG_DESCRIPTION="Utility for matching X11 windows and performing actions on them"
+TERMUX_PKG_LICENSE="GPL-2.0"
+TERMUX_PKG_MAINTAINER="Rafael Kitover <rkitover@gmail.com>"
+TERMUX_PKG_VERSION=0.23
+TERMUX_PKG_SRCURL=http://deb.debian.org/debian/pool/main/d/devilspie/devilspie_${TERMUX_PKG_VERSION}.orig.tar.xz
+TERMUX_PKG_SHA256=2dd9d4b7424ac999f20c214b0ff71e8c5836d97003d7a8a7391105cd16d36deb
+TERMUX_PKG_DEPENDS="libx11, gettext, glib, gtk3, libwnck"
+
+# These patches are from the Debian package.
+termux_step_patch_package() {
+	cd $TERMUX_PKG_SRCDIR
+	patch -p1 -i ${TERMUX_PKG_BUILDER_DIR}/fix_manpage_lintian_warnings.patch
+	patch -p1 -i ${TERMUX_PKG_BUILDER_DIR}/fix_memleak_in_my_wnck_get_viewport_start.patch
+	patch -p1 -i ${TERMUX_PKG_BUILDER_DIR}/fix_using_deprecated_wnck_functions.patch
+	patch -p1 -i ${TERMUX_PKG_BUILDER_DIR}/remove_unavailable_options_from_manpage.patch	
+}

--- a/packages/devilspie/fix_manpage_lintian_warnings.patch
+++ b/packages/devilspie/fix_manpage_lintian_warnings.patch
@@ -1,0 +1,25 @@
+Author: Andreas Rönnquist
+Description: Fixes lintian warnings on the manpage, already fixed 
+ in upstream git, but not in time for version 0.23.
+Index: devilspie-0.23/devilspie.1
+===================================================================
+--- devilspie-0.23.orig/devilspie.1	2012-10-01 11:30:43.000000000 +0200
++++ devilspie-0.23/devilspie.1	2012-10-26 20:05:09.628490721 +0200
+@@ -31,7 +31,7 @@
+ 
+ .SH "ALLOWED SYMBOLS"
+ In the input files, the following symbols are known by \fIdevilspie\fR:
+-."SYMBOL HELP BEGINS HERE
++.\"SYMBOL HELP BEGINS HERE
+ .TP
+ \fBis\fR
+ String equality, (is a b) means a is the same as b.
+@@ -164,7 +164,7 @@
+ .TP
+ \fBspawn_sync\fR
+ Execute a command in the foreground (returns command output as string, or FALSE on error). Command is given as a single string, or as a series of strings (similar to execl).
+-."SYMBOL HELP ENDS HERE
++.\"SYMBOL HELP ENDS HERE
+ 
+ .SH BUGS
+ This manpage is almost useless, as it was thrown together on a train.

--- a/packages/devilspie/fix_memleak_in_my_wnck_get_viewport_start.patch
+++ b/packages/devilspie/fix_memleak_in_my_wnck_get_viewport_start.patch
@@ -1,0 +1,28 @@
+Author: Andreas Rönnquist <gusnan@gusnan.se>
+Description: Fix my_wnck_get_viewport memleak
+ Fixes a memleak in the my_wnck_get_viewport_start function where the result
+ from my_wnck_get_cardinal_list wasn't freed correctly. It is already fixed
+ in upstream git repository, but not in a release yet - See
+ https://git.gnome.org/browse/devilspie/commit/?id=6b1af1227658ac333bfab407e02f3de6452d6de1
+--- a/src/xutils.c
++++ b/src/xutils.c
+@@ -286,13 +286,14 @@
+ {
+   gulong *list;
+   int len;
++  int result = -1;
+ 
+   my_wnck_get_cardinal_list (RootWindowOfScreen (my_wnck_window_get_xscreen (win)),
+                             my_wnck_atom_get ("_NET_DESKTOP_VIEWPORT"), &list, &len);
+ 
+-  if (len > 0) {
+-    return list[0];
+-  } else {
+-    return -1;
+-  }
++  if (len > 0) result=list[0];
++
++  g_free(list);
++
++  return result;
+ }

--- a/packages/devilspie/fix_using_deprecated_wnck_functions.patch
+++ b/packages/devilspie/fix_using_deprecated_wnck_functions.patch
@@ -1,0 +1,26 @@
+Author: Andreas Rönnquist <gusnan@gusnan.se>
+Description: Do not use depreceated libwnck function wnck_class_group_get_res_class
+ This patch makes the source use the wnck_class_group_get_id function instead
+ of the deprecated wnck_class_group_res_class
+--- a/src/actions.c
++++ b/src/actions.c
+@@ -43,7 +43,7 @@
+   g_print(_("Window Title: '%s'; Application Name: '%s'; Class: '%s'; Geometry: %dx%d+%d+%d\n"),
+           wnck_window_get_name (c->window),
+           wnck_application_get_name (wnck_window_get_application (c->window)),
+-          wnck_class_group_get_res_class (wnck_window_get_class_group (c->window)),
++          wnck_class_group_get_id (wnck_window_get_class_group (c->window)),
+           width, height, xoffset, yoffset);
+   
+   return e_sexp_result_new_bool (f, TRUE);
+--- a/src/matchers.c
++++ b/src/matchers.c
+@@ -71,7 +71,7 @@
+ ESExpResult *func_window_class(ESExp *f, int argc, ESExpResult **argv, Context *c) {
+   ESExpResult *r;
+   r = e_sexp_result_new(f, ESEXP_RES_STRING);
+-  r->value.string = g_strdup (wnck_class_group_get_res_class (wnck_window_get_class_group (c->window)));
++  r->value.string = g_strdup (wnck_class_group_get_id (wnck_window_get_class_group (c->window)));
+   if (r->value.string == NULL) r->value.string = g_strdup("");
+   return r;
+ }

--- a/packages/devilspie/remove_unavailable_options_from_manpage.patch
+++ b/packages/devilspie/remove_unavailable_options_from_manpage.patch
@@ -1,0 +1,18 @@
+Author: Andreas Rönnquist <gusnan@gusnan.se>
+Description: Remove unavailable options from the manual page
+ Removes options in the manual page that isn't available in the program.
+--- a/devilspie.1
++++ b/devilspie.1
+@@ -22,12 +22,6 @@
+ .TP
+ \fB\-d\fR \fB\-\-debug\fR
+ Output debug information
+-.TP
+-\fB\-l\fR \fB\-\-list\-symbols\fR
+-List available symbols supported in input files.
+-.TP
+-\fB\-s\fR \fIsymname\fR \fB\-\-symbol\-doc\fR=\fIsymname\fR
+- Get detailed help on symbol \fIsymname\fR ('all' for all symbols).
+ 
+ .SH "ALLOWED SYMBOLS"
+ In the input files, the following symbols are known by \fIdevilspie\fR:


### PR DESCRIPTION
This is a user daemon utility that reads configuration files in lisp for
matching X11 windows and performing actions on them.

For example, I have this file:

~/.devilspie/undecorate.ds

with this contents:

(if (or (is (window_class) "qterminal") (is (window_class)
"Xfce4-terminal"))
	(undecorate)
)

With the daemon launched from my xstartup, when a window matching the
class "qtermina" or "Xfce4-terminal" is opened, it will remove window
manager decorations from it giving me a borderless window without a
title bar.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>